### PR TITLE
Update errno and trace actions [SemVer change]

### DIFF
--- a/libseccomp-sys/src/lib.rs
+++ b/libseccomp-sys/src/lib.rs
@@ -13,12 +13,12 @@
 /// because the bindgen cannot expand the macros correctly.
 ///
 /// Return the specified error code
-pub fn SCMP_ACT_ERRNO(x: u32) -> u32 {
-    0x00050000 | ((x) & 0x0000ffff)
+pub fn SCMP_ACT_ERRNO(x: u16) -> u32 {
+    0x00050000_u32 | u32::from(x)
 }
 /// Notify a tracing process with the specified value
-pub fn SCMP_ACT_TRACE(x: u32) -> u32 {
-    0x7ff00000 | ((x) & 0x0000ffff)
+pub fn SCMP_ACT_TRACE(x: u16) -> u32 {
+    0x7ff00000_u32 | u32::from(x)
 }
 
 include!("./libseccomp_bindings.rs");


### PR DESCRIPTION
1. Update `libseccomp_sys::SCMP_ACT_ERRNO` and
   `libseccomp_sys::SCMP_ACT_TRACE` to take an `u16` instead of an `u32`.

   `man 3 seccomp_rule_add` says that they take an `uint16_t`:

   > **SCMP_ACT_ERRNO(uint16_t errno)**
   >   The thread will receive a return value of errno when it calls a syscall
   >   that matches the filter rule.
   >
   > **SCMP_ACT_TRACE(uint16_t msg_num)**
   >    If  the  thread  is being traced and the tracing process specified the
   >    PTRACE_O_TRACESECCOMP option in the call to ptrace(2), the tracing
   >    process will be notified, via PTRACE_EVENT_SECCOMP , and the value
   >    provided in msg_num  can be retrieved using the PTRACE_GETEVENTMSG option.
2. Update `libseccomp::ScmpAction` accordingly, except for
   `ScmpAction::Errno` which take an `c_int` to make
   `ScmpAction::Errno(libc::EPERM)` work without casting/TryInto/TryFrom.
3. Update `ScmpAction::from_str` to take `msg_num` as it's own argument.
4. Update tests