### PR TITLE
add_rule: Return an error if comparators is to long

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -1079,4 +1079,42 @@ mod tests {
             -111
         );
     }
+
+    #[test]
+    fn test_scmp_arg_cmp_from_scmpargcompare() {
+        // scmp_arg_cmp does not implement PartialEq, that's why we destruct
+        // the struct and assert_eq the individual fields.
+
+        let scmp_arg_cmp {
+            arg,
+            op,
+            datum_a,
+            datum_b,
+        } = <scmp_arg_cmp as From<ScmpArgCompare>>::from(ScmpArgCompare {
+            arg: 0,
+            op: ScmpCompareOp::Equal,
+            datum_a: 1,
+            datum_b: 0,
+        });
+        assert_eq!(arg, 0);
+        assert_eq!(op, scmp_compare::SCMP_CMP_EQ);
+        assert_eq!(datum_a, 1);
+        assert_eq!(datum_b, 0);
+
+        let scmp_arg_cmp {
+            arg,
+            op,
+            datum_a,
+            datum_b,
+        } = <scmp_arg_cmp as From<&ScmpArgCompare>>::from(&ScmpArgCompare {
+            arg: 0,
+            op: ScmpCompareOp::Equal,
+            datum_a: 1,
+            datum_b: 0,
+        });
+        assert_eq!(arg, 0);
+        assert_eq!(op, scmp_compare::SCMP_CMP_EQ);
+        assert_eq!(datum_a, 1);
+        assert_eq!(datum_b, 0);
+    }
 }

--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -214,6 +214,17 @@ impl From<ScmpArgCompare> for scmp_arg_cmp {
     }
 }
 
+impl From<&ScmpArgCompare> for scmp_arg_cmp {
+    fn from(v: &ScmpArgCompare) -> scmp_arg_cmp {
+        scmp_arg_cmp {
+            arg: v.arg,
+            op: v.op.to_native(),
+            datum_a: v.datum_a,
+            datum_b: v.datum_b,
+        }
+    }
+}
+
 /// ScmpAction represents an action to be taken on a filter rule match in libseccomp
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -531,15 +542,7 @@ impl ScmpFilterContext {
 
         match comparators {
             Some(cmps) => {
-                let mut arg_cmp: Vec<scmp_arg_cmp> = Vec::new();
-                for cmp in cmps {
-                    arg_cmp.push(scmp_arg_cmp {
-                        arg: cmp.arg,
-                        op: cmp.op.to_native(),
-                        datum_a: cmp.datum_a,
-                        datum_b: cmp.datum_b,
-                    });
-                }
+                let arg_cmp: Vec<scmp_arg_cmp> = cmps.iter().map(From::from).collect();
 
                 ret = unsafe {
                     seccomp_rule_add_array(


### PR DESCRIPTION
Vec::len returns an usize which is bigger than an u32 on some platforms.
Let's return an error in the rare cases where you have more than
u32::MAX comparators instead of silently truncating the len.