### PR TITLE
Make `ScmpArgCompare::new` `const`

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -193,12 +193,18 @@ pub struct ScmpArgCompare {
 }
 
 impl ScmpArgCompare {
-    pub fn new(arg: u32, op: ScmpCompareOp, datum_a: u64, datum_b: Option<u64>) -> Self {
+    pub const fn new(arg: u32, op: ScmpCompareOp, datum_a: u64, datum_b: Option<u64>) -> Self {
+        let datum_b = if let Some(datum_b) = datum_b {
+            datum_b
+        } else {
+            0
+        };
+
         Self {
             arg,
             op,
             datum_a,
-            datum_b: datum_b.unwrap_or(0_u64),
+            datum_b,
         }
     }
 }


### PR DESCRIPTION
This allows to define blocklists in `const`ants:

```rust
use libseccomp::*;

type SyscallBlocklist = &'static [(ScmpAction, &'static str, Option<&'static [ScmpArgCompare]>)];
const SYSCALL_BLOCKLIST: SyscallBlocklist = &[
    (ScmpAction::Errno(libc::EPERM as u32), "execve", None),
    (ScmpAction::Errno(libc::EPERM as u32), "execveat", None),
    (ScmpAction::Errno(libc::EPERM as u32), "creat", Some(&[ScmpArgCompare::new(1, ScmpCompareOp::Equal, 0o755, None)])),
];

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let mut filter = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
    for &(action, syscall, comparators) in SYSCALL_BLOCKLIST {
        let syscall_nr = get_syscall_from_name(syscall, None)?;
        filter.add_rule(action, syscall_nr, comparators)?;
    }
    filter.load()?;
    Ok(())
}
```