### PR TITLE
Security: Do not derive Clone on ScmpFilterContext

### DIFF
--- a/libseccomp/src/lib.rs
+++ b/libseccomp/src/lib.rs
@@ -426,7 +426,7 @@ pub struct ScmpData {
 }
 
 /// ScmpFilterContext represents a filter context in libseccomp.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ScmpFilterContext {
     ctx: NonNull<libc::c_void>,
 }


### PR DESCRIPTION
Deriving Clone for ScmpFilterContext causes double-free (CWE-415) and
use-after-free (CWE-416) with the current Drop implementation.

`double-free.rs`:
```rust
use libseccomp::*;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let filter1 = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
    let filter2 = filter1.clone();
    drop(filter1);
    drop(filter2);

    Ok(())
}
```

`use-after-free.rs`:
```rust
use libseccomp::*;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let mut filter = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
    drop(filter.clone());
    filter.reset(ScmpAction::Allow)?;

    Ok(())
}
```